### PR TITLE
Compatibiliy with upstream vllm-project/vllm repository

### DIFF
--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -13,16 +13,16 @@ jobs:
       run: |
         docker run -i --rm --entrypoint /bin/bash vllm-spyre -c '''
           pip install pytest sentence-transformers && \
-          python3.12 -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
+          python -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
           export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
           mkdir -p /models && \
           ln -s /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/${VARIANT} /models/llama-194m && \
-          python3.12 -c "from sentence_transformers import SentenceTransformer; SentenceTransformer(\"sentence-transformers/all-roberta-large-v1\")" && \
+          python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer(\"sentence-transformers/all-roberta-large-v1\")" && \
           export VARIANT=$(ls /root/.cache/huggingface/hub/models--sentence-transformers--all-roberta-large-v1/snapshots/) && \
           ln -s /root/.cache/huggingface/hub/models--sentence-transformers--all-roberta-large-v1/snapshots/${VARIANT} /models/all-roberta-large-v1 && \
           export MASTER_PORT=12355 && \
           export MASTER_ADDR=localhost && \
           export DISTRIBUTED_STRATEGY_IGNORE_MODULES=WordEmbedding && \
           cd vllm-spyre && \
-          python3.12 -m pytest tests -v
+          python -m pytest tests -v
         '''

--- a/Dockerfile.spyre
+++ b/Dockerfile.spyre
@@ -12,17 +12,14 @@ WORKDIR /workspace
 RUN microdnf update -y && microdnf install -y \
     python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip python${PYTHON_VERSION}-wheel git vim gcc g++ kmod\
     && microdnf clean all
+RUN ln -sf $(which python${PYTHON_VERSION}) /usr/bin/python && \
+    ln -sf $(which pip${PYTHON_VERSION}) /usr/bin/pip
 
 # Download and install vllm ###########################################################
-ENV VLLM_TARGET_DEVICE=empty
-RUN git clone -b sop-plugin-refactoring --single-branch https://github.com/IBM/vllm.git \
-    && cd vllm \
-    && python3.12 -m pip install --upgrade pip \
-    && pip install -r requirements-build.txt \
-    && pip install --no-build-isolation -v -e . \
-    && mkdir /workspace/vllm-spyre
+RUN pip install vllm==0.7.3
 
 # Install vllm Spyre plugin ##################################################################
+RUN mkdir /workspace/vllm-spyre
 COPY . /workspace/vllm-spyre
 RUN cd /workspace/vllm-spyre && pip install --no-build-isolation -v -e .
 ENV VLLM_PLUGINS=spyre

--- a/README.md
+++ b/README.md
@@ -24,11 +24,7 @@ docker run -it --rm vllm-spyre bash
 
 ```
 # Install vllm
-git clone https://github.com/vllm-project/vllm.git
-cd vllm
-pip install -r requirements-build.txt
-export VLLM_TARGET_DEVICE=empty
-pip install --no-build-isolation -v -e .
+pip install vllm==0.7.3
 
 # Install vllm-spyre
 cd ..

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -104,7 +104,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
 
     def get_model(self) -> nn.Module:
         return self.model
-    
+
     def load_model(self, prompt_lens: Iterable[int],
                    num_decode_tokens: Iterable[int]) -> None:
         max_pad_length = max(prompt_lens)

--- a/vllm_spyre/worker/spyre_model_runner.py
+++ b/vllm_spyre/worker/spyre_model_runner.py
@@ -102,6 +102,9 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         # Lazy initialization: after load_model.
         self.model: nn.Module
 
+    def get_model(self) -> nn.Module:
+        return self.model
+    
     def load_model(self, prompt_lens: Iterable[int],
                    num_decode_tokens: Iterable[int]) -> None:
         max_pad_length = max(prompt_lens)


### PR DESCRIPTION
Ensuring compatibility with the latest upstream release `v.0.7.3`. Since there has been a new abstract method introduced in the base model runner, we have to define it in the Spyre model runner which inherits from the base class. 

**changes:**
- adding `get_model()` function in `SpyreModelRunner` as required by abstract base class `ModelRunnerBase` ([link](https://github.com/vllm-project/vllm/blob/bfbc0b32c6dbea5aea6b14724acaca515d23a28a/vllm/worker/model_runner_base.py#L222) to  upstream base class abstract method)
- syncing `vllm-spyre/core/scheuduler.py` with the upstream scheduler `v.0.7.3`. 
- Adding comments `# SPYRE SPECIFIC CODE BLOCK START` and `# SPYRE SPECIFIC CODE BLOCK END` to mark the Spyre specific code blocks.
- changed docker file to install vllm v0.7.3 from pip wheel. 
- created symlinks for `python->python${PYTHON_VERSION}` and `pip->pip${PYTHON_VERSION}` to only have the python version hard coded in the docker file: `ARG PYTHON_VERSION=3.12`

Tested vllm-spyre plugin with release `v.0.7.3` ([commit](https://github.com/vllm-project/vllm/commit/ed6e9075d31e32c8548b480a47d1ffb77da1f54c)) on Spyre successfully. 